### PR TITLE
small typos in switchpalette

### DIFF
--- a/plugins/notebook/ui/Buttons/SwitchPalette.tid
+++ b/plugins/notebook/ui/Buttons/SwitchPalette.tid
@@ -13,7 +13,7 @@ type: text/vnd.tiddlywiki
   </$list>
 
   <$list filter="[<tv-config-toolbar-text>match[yes]]">
-    <span class="tc-btn-text">Switch colours/></span>
+    <span class="tc-btn-text">Switch colours</span>
   </$list>
 
   <$reveal type="match" state="$:/palette" text="$:/themes/nico/notebook/palette-beige">


### PR DESCRIPTION
This patch correct the small type in SwitchPalette.tid

See the typo in sidebar under Tools tab.

![333_chrome](https://user-images.githubusercontent.com/830394/102044171-8309d280-3deb-11eb-9845-19f774648331.png)
