### PR TITLE
Allow text in the sidebar to wrap

### DIFF
--- a/plugins/notebook/base.tid
+++ b/plugins/notebook/base.tid
@@ -217,7 +217,7 @@ h1.tc-site-title {
   text-overflow: ellipsis;
   padding-top: 10px;
   z-index: 500;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .nc-sidebar .segment {


### PR DESCRIPTION
Currently, all text in the sidebar such as the wiki title, subtitle, headings and contents of sidebar stay on one line, and thus longer sentences are not readable. Changing no-wrap to normal allows text to wrap to the next line.

